### PR TITLE
Add authentication wall

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,8 @@
-export default async function authenticate(
+export interface AuthenticationProps {
+	setAuthentication?: (authenticated: boolean) => void;
+}
+
+export async function authenticate(
 	setAuthentication: (data: boolean) => void
 ): Promise<void> {
 	await fetch("http://localhost:8000/authenticate", {

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -3,8 +3,6 @@ import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import CssBaseline from "@mui/material/CssBaseline";
 import TextField from "@mui/material/TextField";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Checkbox from "@mui/material/Checkbox";
 import Link from "@mui/material/Link";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
@@ -13,8 +11,7 @@ import Typography from "@mui/material/Typography";
 import Container from "@mui/material/Container";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
-import authenticate from "../auth";
+import { authenticate, AuthenticationProps } from "../auth";
 
 function Copyright() {
 	return (
@@ -31,13 +28,8 @@ function Copyright() {
 
 const theme = createTheme();
 
-export default function Login(): JSX.Element {
-	const [isAuthenticated, setAuthentication] = useState(false);
+export default function Login(props: AuthenticationProps): JSX.Element {
 	const navigate = useNavigate();
-
-	useEffect(() => {
-		authenticate(setAuthentication);
-	}, []);
 
 	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
@@ -52,15 +44,12 @@ export default function Login(): JSX.Element {
 		}).catch(err => {
 			console.log("Error logging in: " + err);
 		});
-		navigate("/play");
+		if (props.setAuthentication !== undefined) {
+			await authenticate(props.setAuthentication);
+		}
+		navigate("/");
 	}
-	if (isAuthenticated) {
-		return (
-			<div>
-				ALREADY LOGGED IN, go <Link href="/play">play!</Link>
-			</div>
-		);
-	}
+
 	return (
 		<ThemeProvider theme={theme}>
 			<Container component="main" maxWidth="xs">
@@ -107,12 +96,6 @@ export default function Login(): JSX.Element {
 							id="password"
 							autoComplete="current-password"
 						/>
-						<FormControlLabel
-							control={
-								<Checkbox value="remember" color="primary" />
-							}
-							label="Remember me"
-						/>
 						<Button
 							type="submit"
 							fullWidth
@@ -121,11 +104,6 @@ export default function Login(): JSX.Element {
 							Sign In
 						</Button>
 						<Grid container>
-							<Grid item xs>
-								<Link href="#" variant="body2">
-									Forgot password?
-								</Link>
-							</Grid>
 							<Grid item>
 								<Link href="/signup" variant="body2">
 									{"Don't have an account? Sign Up"}

--- a/src/routes/logout.tsx
+++ b/src/routes/logout.tsx
@@ -1,0 +1,39 @@
+import Button from "@mui/material/Button";
+import CssBaseline from "@mui/material/CssBaseline";
+import Container from "@mui/material/Container";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { AuthenticationProps } from "../auth";
+
+const theme = createTheme();
+
+export default function Logout(props: AuthenticationProps): JSX.Element {
+	async function logout() {
+		await fetch("http://localhost:8000/logout", {
+			method: "GET",
+			mode: "cors",
+			credentials: "include",
+			headers: {
+				Accept: "application/json",
+			},
+		}).catch(err => {
+			console.log("Error logging out: " + err);
+		});
+		if (props.setAuthentication !== undefined) {
+			props.setAuthentication(false);
+		}
+	}
+	return (
+		<ThemeProvider theme={theme}>
+			<Container component="main" maxWidth="xs">
+				<CssBaseline />
+				<Button
+					fullWidth
+					variant="contained"
+					sx={{ mt: 3, mb: 2 }}
+					onClick={logout}>
+					Logout
+				</Button>
+			</Container>
+		</ThemeProvider>
+	);
+}

--- a/src/routes/play.tsx
+++ b/src/routes/play.tsx
@@ -1,6 +1,17 @@
-import { useState, useEffect, FunctionComponent } from "react";
-import { TextField } from "@mui/material";
-import authenticate from "../auth";
+import { useState, useEffect } from "react";
+import {
+	Container,
+	createTheme,
+	CssBaseline,
+	TextField,
+	ThemeProvider,
+} from "@mui/material";
+import { authenticate } from "../auth";
+import Login from "./login";
+import Logout from "./logout";
+import { Box } from "@mui/system";
+
+const theme = createTheme();
 
 type Message = {
 	room: string;
@@ -69,14 +80,29 @@ export default function Play(): JSX.Element {
 	}
 
 	if (!isAuthenticated) {
-		return <></>;
+		return <Login setAuthentication={setAuthentication} />;
 	}
 	return (
-		<div className="App">
-			<header className="App-header">
-				<div className="text">{currentWord + " " + sampleText}</div>
-				<TextField onChange={validate} label="type here" />
-			</header>
-		</div>
+		<ThemeProvider theme={theme}>
+			<Container
+				component="main"
+				maxWidth="sm"
+				sx={{
+					marginTop: 8,
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+				}}>
+				<CssBaseline />
+				<Box
+					sx={{
+						fontSize: 35,
+					}}>
+					{currentWord + " " + sampleText}
+				</Box>
+				<TextField fullWidth onChange={validate} label="type here" />
+				<Logout setAuthentication={setAuthentication} />
+			</Container>
+		</ThemeProvider>
 	);
 }


### PR DESCRIPTION
This PR adds the login/signup page as a blocker to the actual application. If there is no authentication there is no possibility to reach that page. 

I still want to add the authentication state to the `localStorage` in order to not request the backend on every reload.